### PR TITLE
Fix code scanning alert no. 6: Wrong type of arguments to formatting function

### DIFF
--- a/tnm/snmp/tnmAsn1.c
+++ b/tnm/snmp/tnmAsn1.c
@@ -310,8 +310,8 @@ TnmBerSetError(TnmBer *ber, char *msg)
 void
 TnmBerWrongValue(TnmBer *ber, u_char tag)
 {
-    sprintf(ber->error, "invalid value for tag 0x%.2x at byte %d",
-	    tag, ber->current - ber->start);
+    sprintf(ber->error, "invalid value for tag 0x%.2x at byte %ld",
+	    tag, (long)(ber->current - ber->start));
 }
 
 /*


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/scotty/security/code-scanning/6](https://github.com/cooljeanius/scotty/security/code-scanning/6)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since the result of subtracting two pointers is of type `ptrdiff_t`, which is typically a `long`, we should use the `%ld` format specifier for the subtraction result. This change will ensure that the `sprintf` function interprets the argument correctly, preventing undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
