### PR TITLE
Fix code scanning alert no. 5: Wrong type of arguments to formatting function

### DIFF
--- a/tnm/snmp/tnmAsn1.c
+++ b/tnm/snmp/tnmAsn1.c
@@ -334,8 +334,8 @@ TnmBerWrongValue(TnmBer *ber, u_char tag)
 void
 TnmBerWrongLength(TnmBer *ber, u_char tag, int length)
 {
-    sprintf(ber->error, "invalid length %d for tag 0x%.2x at byte %d", 
-	    length, tag, ber->current - ber->start);
+    sprintf(ber->error, "invalid length %d for tag 0x%.2x at byte %ld", 
+	    length, tag, (long)(ber->current - ber->start));
 }
 
 /*


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/scotty/security/code-scanning/5](https://github.com/cooljeanius/scotty/security/code-scanning/5)

To fix the problem, we need to ensure that the format specifier matches the type of the argument being passed. Since `ber->current - ber->start` is of type `long`, we should use the `%ld` format specifier instead of `%d`. This change will ensure that the `sprintf` function correctly interprets the argument as a `long` type, preventing any potential undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
