### PR TITLE
Fix code scanning alert no. 4: Wrong type of arguments to formatting function

### DIFF
--- a/tnm/snmp/tnmAsn1.c
+++ b/tnm/snmp/tnmAsn1.c
@@ -359,11 +359,11 @@ void
 TnmBerWrongTag(TnmBer *ber, u_char tag, u_char expected)
 {
     if (expected) {
-	sprintf(ber->error, "invalid tag 0x%.2x at byte %d (expected 0x%.2x)",
-		tag, ber->current - ber->start, expected);
+	sprintf(ber->error, "invalid tag 0x%.2x at byte %ld (expected 0x%.2x)",
+		tag, (long)(ber->current - ber->start), expected);
     } else {
-	sprintf(ber->error, "invalid tag 0x%.2x at byte %d", tag,
-		ber->current - ber->start);
+	sprintf(ber->error, "invalid tag 0x%.2x at byte %ld", tag,
+		(long)(ber->current - ber->start));
     }
 }
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/scotty/security/code-scanning/4](https://github.com/cooljeanius/scotty/security/code-scanning/4)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. In this case, we should use the `%ld` format specifier for the `long` type. This change will ensure that the `printf` function correctly interprets the `long` value and produces the expected output.

- Change the format specifier from `%d` to `%ld` for the `ber->current - ber->start` argument in the `sprintf` function calls.
- Update the relevant lines in the `TnmBerWrongTag` function to reflect this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
