### PR TITLE
Fix code scanning alert no. 2: Wrong type of arguments to formatting function

### DIFF
--- a/tnm/snmp/tnmAsn1.c
+++ b/tnm/snmp/tnmAsn1.c
@@ -803,7 +803,7 @@ TnmBerDecSequenceEnd(TnmBer *ber, u_char *token, int length)
 	sprintf(ber->error, "sequence %s at byte %ld (%ld bytes missing)",
 		(length > len) ? "underflow" : "overflow",
 		(long)(ber->current - ber->start),
-		(long)((length > len) ? length - len : len - length));
+		(long)((length > len) ? (length - len) : (len - length)));
 	return NULL;
     }
     return ber;

--- a/tnm/snmp/tnmAsn1.c
+++ b/tnm/snmp/tnmAsn1.c
@@ -800,10 +800,10 @@ TnmBerDecSequenceEnd(TnmBer *ber, u_char *token, int length)
 
     len = ber->current - token;
     if (length != len) {
-	sprintf(ber->error, "sequence %s at byte %d (%d bytes missing)",
+	sprintf(ber->error, "sequence %s at byte %ld (%ld bytes missing)",
 		(length > len) ? "underflow" : "overflow",
-		ber->current - ber->start,
-		(length > len) ? length - len : len - length);
+		(long)(ber->current - ber->start),
+		(long)((length > len) ? length - len : len - length));
 	return NULL;
     }
     return ber;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/scotty/security/code-scanning/2](https://github.com/cooljeanius/scotty/security/code-scanning/2)

To fix the problem, we need to ensure that the format specifier in the `sprintf` function matches the type of the arguments provided. Since the result of subtracting two pointers is of type `ptrdiff_t`, which is typically a `long`, we should use the `%ld` format specifier for `long` instead of `%d` for `int`.

- Change the format specifier from `%d` to `%ld` in the `sprintf` function call on line 805.
- Ensure that the arguments passed to the `sprintf` function match the expected types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
