### PR TITLE
Fix code scanning alert no. 1: Wrong type of arguments to formatting function

### DIFF
--- a/tnm/generic/tnmObj.c
+++ b/tnm/generic/tnmObj.c
@@ -555,7 +555,7 @@ UpdateStringOfUnsigned32(Tcl_Obj *objPtr)
     TnmUnsigned32 u = (TnmUnsigned32) objPtr->internalRep.longValue;
 
     objPtr->bytes = Tcl_Alloc(30);
-    objPtr->length = sprintf(objPtr->bytes, "%lu", u);
+    objPtr->length = sprintf(objPtr->bytes, "%u", u);
 }
 
 /*


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/scotty/security/code-scanning/1](https://github.com/cooljeanius/scotty/security/code-scanning/1)

To fix the problem, we need to ensure that the format specifier matches the type of the variable being formatted. Since `TnmUnsigned32` is defined as `unsigned int`, we should use the `%u` format specifier instead of `%lu`. This change should be made in the `UpdateStringOfUnsigned32` function where the `sprintf` function is called.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
